### PR TITLE
Create sonarcloud-pixeebot.yml

### DIFF
--- a/.github/workflows/sonarcloud-pixeebot.yml
+++ b/.github/workflows/sonarcloud-pixeebot.yml
@@ -1,0 +1,18 @@
+name: Fix SonarCloud Issues with Pixeebot
+on:
+  check_run:
+    types: [completed]
+
+permissions:
+  id-token: write
+
+jobs:
+  share:
+    name: Upload Sonar Results to Pixeebot
+    runs-on: ubuntu-latest
+    if: ${{ github.event.check_run.name == 'SonarCloud Code Analysis' }}
+    steps:
+      - uses: pixee/upload-tool-results-action@v2
+        with:
+          tool: sonar
+          sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behaviour that you are modifying. -->

* 

### After the change?
<!-- Please describe the behaviour or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been reviewed and added/updated if needed (for bug fixes/features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change, make sure to note it here and what the impact might be -->

- [ ] Yes
- [ ] No

----


<!-- Korbit AI PR Description Start -->
## Description by Korbit AI
> [!NOTE]
> This feature is in early access. You can enable or disable it in the [Korbit Console](https://app.korbit.ai/settings).

### What change is being made?
Add a GitHub Actions workflow file `sonarcloud-pixeebot.yml` to automate the upload of SonarCloud analysis results to Pixeebot.

### Why are these changes being made?
This change is being made to streamline the process of integrating SonarCloud code analysis results with Pixeebot, ensuring that any issues detected by SonarCloud are automatically uploaded and tracked. This approach enhances our CI/CD pipeline by automating a previously manual step, improving efficiency and consistency in our code quality monitoring process.

<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow to automate the upload of SonarCloud analysis results for the Pixeebot project.
  
- **Improvements**
	- Enhanced integration with SonarCloud, improving continuous integration and quality assurance processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->